### PR TITLE
Improve makeAdl/Db scripts

### DIFF
--- a/scripts/makeAdl.py
+++ b/scripts/makeAdl.py
@@ -529,7 +529,7 @@ for name, nodes in structure:
         nx += labelWidth + 5
         if node.nodeName in ["StringReg"] or ro:
             text += make_ro()
-        elif node.nodeName in ["Integer", "Float", "Converter", "IntConverter", "IntSwissKnife", "SwissKnife"]:  
+        elif node.nodeName in ["Integer", "IntReg", "Float", "Converter", "IntConverter", "IntSwissKnife", "SwissKnife"]:  
             text += make_demand()
             nx += textEntryWidth + 5 
             text += make_rbv() 

--- a/scripts/makeAdl.py
+++ b/scripts/makeAdl.py
@@ -527,9 +527,9 @@ for name, nodes in structure:
             labelHeight = 10
         text += make_label()
         nx += labelWidth + 5
-        if node.nodeName in ["StringReg"] or ro:
+        if ro:
             text += make_ro()
-        elif node.nodeName in ["Integer", "IntReg", "Float", "Converter", "IntConverter", "IntSwissKnife", "SwissKnife"]:  
+        elif node.nodeName in ["Integer", "IntReg", "Float", "Converter", "IntConverter", "IntSwissKnife", "SwissKnife", "StringReg"]:
             text += make_demand()
             nx += textEntryWidth + 5 
             text += make_rbv() 

--- a/scripts/makeAdl.py
+++ b/scripts/makeAdl.py
@@ -529,7 +529,7 @@ for name, nodes in structure:
         nx += labelWidth + 5
         if ro:
             text += make_ro()
-        elif node.nodeName in ["Integer", "IntReg", "Float", "Converter", "IntConverter", "IntSwissKnife", "SwissKnife", "StringReg"]:
+        elif node.nodeName in ["Integer", "IntReg", "Float", "Converter", "IntConverter", "IntSwissKnife", "SwissKnife", "StringReg", "String"]:
             text += make_demand()
             nx += textEntryWidth + 5 
             text += make_rbv() 

--- a/scripts/makeDb.py
+++ b/scripts/makeDb.py
@@ -157,7 +157,7 @@ print()
 for node in doneNodes:
     nodeName = str(node.getAttribute("Name"))
     ro = is_node_readonly(node)
-    if node.nodeName in ["Integer", "IntConverter", "IntSwissKnife"]:
+    if node.nodeName in ["Integer", "IntReg", "IntConverter", "IntSwissKnife"]:
         print('record(%s, "$(P)$(R)%s_RBV") {' % (GCIntegerInputRecordType, records[nodeName]))
         print('  field(DTYP, "asynInt64")')
         print('  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_%s")' % nodeName)

--- a/scripts/makeDb.py
+++ b/scripts/makeDb.py
@@ -219,6 +219,14 @@ for node in doneNodes:
         print('  field(DISA, "0")')
         print('}')
         print()
+        if ro:
+            continue
+        print('record(stringout, "$(P)$(R)%s") {' % records[nodeName])
+        print('  field(DTYP, "asynOctetWrite")')
+        print('  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_S_%s")' % nodeName)
+        print('  field(DISA, "0")')
+        print('}')
+        print()
     elif node.nodeName in ["Command"]:
         print('record(longout, "$(P)$(R)%s") {' % records[nodeName])
         print('  field(DTYP, "asynInt32")')

--- a/scripts/makeDb.py
+++ b/scripts/makeDb.py
@@ -211,7 +211,7 @@ for node in doneNodes:
         print('  field(DISA, "0")')
         print('}')
         print()
-    elif node.nodeName in ["StringReg"]:
+    elif node.nodeName in ["StringReg", "String"]:
         print('record(stringin, "$(P)$(R)%s_RBV") {' % records[nodeName])
         print('  field(DTYP, "asynOctetRead")')
         print('  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_S_%s")' % nodeName)


### PR DESCRIPTION
* Check recursively *AccessMode* for nodes with _pValue_ defined. e.g. **FirmwareVerMinor** refers **RegFirmwareVerMinor**, which has the *AccessMode* defined.
https://github.com/areaDetector/ADGenICam/blob/da91e915f6373f74bbc04e1c0c188d0ff3aa3870/xml/AVT_Mako_G507B.xml#L383-L388
https://github.com/areaDetector/ADGenICam/blob/da91e915f6373f74bbc04e1c0c188d0ff3aa3870/xml/AVT_Mako_G507B.xml#L3412-L3419
* Add *String* nodes support. According to [GenICam Standard](https://www.emva.org/wp-content/uploads/GenICam_Standard_v2_1_1.pdf) section 2.8.12, *String* is of variable length compared to *StringReg*. Both are possibly writable, e.g. *DeviceUserID*
https://github.com/areaDetector/ADGenICam/blob/da91e915f6373f74bbc04e1c0c188d0ff3aa3870/xml/AVT_Mako_G507B.xml#L3495-L3502
* Add *IntReg* nodes support. It is often used for internal features. But in a Basler acA1300-200uc camera, it is used for **EventExposureEnd** feature.
```
  <IntReg Name="EventExposureEnd" NameSpace="Standard">
    <ToolTip>Unique identifier of the Exposure End event.</ToolTip>
    <Description>Unique identifier of the Exposure End event. Use this parameter to get notified when the event occurs.</Description>
    <DisplayName>Event Exposure End</DisplayName>
    <Visibility>Expert</Visibility>
    <Address>0x2</Address>
    <Length>2</Length>
    <AccessMode>RO</AccessMode>
    <pPort>EventExposureEndEventPort</pPort>
    <Sign>Unsigned</Sign>
    <Endianess>LittleEndian</Endianess>
  </IntReg>
```

