### PR TITLE
Map TemperatureAbs feature to ADTemperatureActual PV

### DIFF
--- a/GenICamApp/src/ADGenICam.cpp
+++ b/GenICamApp/src/ADGenICam.cpp
@@ -471,7 +471,6 @@ asynStatus ADGenICam::addADDriverFeatures()
         {ADNumImages,         "AcquisitionFrameCount", GCFeatureTypeInteger},
         {ADGain,              "Gain",                  GCFeatureTypeDouble},
         {ADTriggerMode,       "TriggerMode",           GCFeatureTypeEnum},
-        {ADTemperatureActual, "DeviceTemperature",     GCFeatureTypeDouble},
         {GCTriggerSource,     "TriggerSource",         GCFeatureTypeEnum},
         {GCTriggerOverlap,    "TriggerOverlap",        GCFeatureTypeEnum},
         {GCTriggerSoftware,   "TriggerSoftware",       GCFeatureTypeCmd},
@@ -541,6 +540,11 @@ asynStatus ADGenICam::addADDriverFeatures()
                 {"GainRaw",         GCFeatureTypeInteger},
                 {"GainRawChannelA", GCFeatureTypeInteger}};
     createMultiFeature(ADGainString, asynParamFloat64, ADGain, features);
+
+    // Make a single parameter that maps to either DeviceTemperature or TemperatureAbs
+    features = {{"DeviceTemperature", GCFeatureTypeDouble},
+                {"TemperatureAbs",    GCFeatureTypeDouble}};
+    createMultiFeature(ADTemperatureActualString, asynParamFloat64, ADTemperatureActual, features);
 
     return asynSuccess;
 }


### PR DESCRIPTION
Basler cameras implement temperature feature as [TemperatureAbs][1] instead of DeviceTemperature. Make this a multi-feature which supports either names to correctly map to the standard ADDriver PV.

I haven't been able to test this yet. I hope I can do this in the following days.

[1]: https://docs.baslerweb.com/temperature-state